### PR TITLE
Cluster-Diagnosis: Get cep in json instead of yaml.

### DIFF
--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -204,8 +204,8 @@ class SysdumpCollector(object):
                      .format(cnp_file_name))
 
     def collect_cep(self):
-        cep_file_name = "cep-{}.yaml".format(utils.get_current_time())
-        cmd = "kubectl get cep -o yaml --all-namespaces > {}/{}".format(
+        cep_file_name = "cep-{}.json".format(utils.get_current_time())
+        cmd = "kubectl get cep -o json --all-namespaces > {}/{}".format(
             self.sysdump_dir_name, cep_file_name)
         try:
             subprocess.check_output(cmd, shell=True)


### PR DESCRIPTION
Had a issue in a xtra large cluster, the cep output was super useful,
but due the size of the yaml, `yq` takes around 5 min to parse.

If the output is in jq, getting information is faster (less than a
second), and it helps to resolve the issue faster.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/53)
<!-- Reviewable:end -->
