### PR TITLE
sysdumpcollector: change max_workers value for ThreadPool executors

### DIFF
--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -96,7 +96,8 @@ class SysdumpCollector(object):
                      .format(pods_summary_file_name))
 
     def collect_logs(self, label_selector, node_ip_filter):
-        pool = ThreadPool(multiprocessing.cpu_count() - 1)
+        pool = ThreadPool(min(32, multiprocessing.cpu_count() + 4))
+
         pool.map(
             self.collect_logs_per_pod,
             utils.get_pods_status_iterator_by_labels(
@@ -181,7 +182,7 @@ class SysdumpCollector(object):
         self.collect_gops(label_selector, node_ip_filter, "stack")
 
     def collect_gops(self, label_selector, node_ip_filter, type_of_stat):
-        pool = ThreadPool(multiprocessing.cpu_count() - 1)
+        pool = ThreadPool(min(32, multiprocessing.cpu_count() + 4))
         pool.map(
             functools.partial(self.collect_gops_per_pod,
                               type_of_stat=type_of_stat),
@@ -308,7 +309,7 @@ class SysdumpCollector(object):
                 secret_file_name))
 
     def collect_cilium_bugtool_output(self, label_selector, node_ip_filter):
-        pool = ThreadPool(multiprocessing.cpu_count())
+        pool = ThreadPool(min(32, multiprocessing.cpu_count() + 4))
         pool.map(
             self.collect_cilium_bugtool_output_per_pod,
             utils.get_pods_status_iterator_by_labels(


### PR DESCRIPTION
A value of `multiprocessing.cpu_count() - 1` may potentially be `0`, which is a problem.

As the tasks performed by `sysdumpcollector` are not typically CPU bound, increase the minimum number of workers and pick the default value that is used in Python 3.8 (`min(32, os.cpu_count() + 4)`) as this also avoids creating too many workers on many-core machines.