### PR TITLE
sysdump: log some data collection errors are warning

### DIFF
--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -207,8 +207,8 @@ class SysdumpCollector(object):
             subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
             if exc.returncode != 0:
-                log.error("Error: {}. Could not collect gops {}: {}"
-                          .format(exc, type_of_stat, file_name))
+                log.warning("Warning: {}. Could not collect gops {}: {}"
+                            .format(exc, type_of_stat, file_name))
         else:
             log.info("collected gops {} file: {}".format(
                 type_of_stat, file_name))
@@ -221,8 +221,8 @@ class SysdumpCollector(object):
             subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
             if exc.returncode != 0:
-                log.error("Error: {}. Could not collect kubernetes network "
-                          "policy: {}".format(exc, netpol_file_name))
+                log.warning("Warning: {}. Could not collect kubernetes network"
+                            " policy: {}".format(exc, netpol_file_name))
         else:
             log.info("collected kubernetes network policy: {}"
                      .format(netpol_file_name))
@@ -235,8 +235,8 @@ class SysdumpCollector(object):
             subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
             if exc.returncode != 0:
-                log.error("Error: {}. Could not collect cilium network "
-                          "policy: {}".format(exc, cnp_file_name))
+                log.warning("Warning: {}. Could not collect cilium network "
+                            "policy: {}".format(exc, cnp_file_name))
         else:
             log.info("collected cilium network policy: {}"
                      .format(cnp_file_name))
@@ -265,8 +265,8 @@ class SysdumpCollector(object):
             subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
             if exc.returncode != 0:
-                log.error("Error: {}. Unable to get {} daemonset yaml"
-                          .format(exc, name))
+                log.warning("Warning: {}. Unable to get {} daemonset yaml"
+                            .format(exc, name))
         else:
             log.info("collected {} daemonset yaml file: {}".format(
                 name, file_name))
@@ -281,8 +281,8 @@ class SysdumpCollector(object):
             subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
             if exc.returncode != 0:
-                log.error("Error: {}. Unable to get cilium configmap yaml"
-                          .format(exc))
+                log.warning("Warning: {}. Unable to get cilium configmap yaml"
+                            .format(exc))
         else:
             log.info("collected cilium configmap yaml file: {}".format(
                 configmap_file_name))
@@ -305,8 +305,8 @@ class SysdumpCollector(object):
                 fp.write(json.dumps(output))
         except subprocess.CalledProcessError as exc:
             if exc.returncode != 0:
-                log.error("Error: {}. Unable to get and redact cilium secret"
-                          .format(exc))
+                log.warning("Warning: {}. Unable to get and redact cilium "
+                            "secret".format(exc))
         else:
             log.info("collected and redacted cilium secret file: {}".format(
                 secret_file_name))

--- a/cilium-sysdump/utils.py
+++ b/cilium-sysdump/utils.py
@@ -149,9 +149,8 @@ def get_pods_status_iterator_by_labels(label_selector, host_ip_filter,
     output = encoded_output.decode()
     if output == "":
         if must_exist:
-            log.error("no pods with labels "
-                      "{} are running on the cluster".format(
-                        label_selector))
+            log.warning("no pods with labels {} are running on the cluster"
+                        .format(label_selector))
         return
 
     # kubectl field selector supports listing pods based on a particular


### PR DESCRIPTION
If collecting the nodes or pods overview fails, it likely indicates a major connectivity problem with the cluster or something of the sort.

However, if log collection for hubble, for instance, cannot be collected it might just mean that hubble is not deployed in this cluster and logging a warning is sufficient in this case.