### PR TITLE
cilium-sysdump: Add support for hubble-relay

### DIFF
--- a/cilium-sysdump/namespace.py
+++ b/cilium-sysdump/namespace.py
@@ -15,3 +15,4 @@
 
 cilium_ns = "kube-system"
 hubble_ns = cilium_ns
+hubble_relay_ns = cilium_ns

--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -42,7 +42,7 @@ class SysdumpCollector(object):
     def __init__(
             self,
             sysdump_dir_name, since, size_limit, output, is_quick_mode,
-            cilium_labels, hubble_labels):
+            cilium_labels, hubble_labels, hubble_relay_labels):
         self.sysdump_dir_name = sysdump_dir_name
         self.since = since
         self.size_limit = size_limit
@@ -50,6 +50,7 @@ class SysdumpCollector(object):
         self.is_quick_mode = is_quick_mode
         self.cilium_labels = cilium_labels
         self.hubble_labels = hubble_labels
+        self.hubble_relay_labels = hubble_relay_labels
 
     def collect_nodes_overview(self):
         nodes_overview_file_name = "nodes-{}.json".format(
@@ -473,6 +474,8 @@ class SysdumpCollector(object):
         self.collect_gops_stats(self.cilium_labels, node_ip_filter)
         log.info("collecting hubble gops stats ...")
         self.collect_gops_stats(self.hubble_labels, node_ip_filter)
+        log.info("collecting hubble-relay gops stats ...")
+        self.collect_gops_stats(self.hubble_relay_labels, node_ip_filter)
         log.info("collecting kubernetes network policy ...")
         self.collect_netpol()
         log.info("collecting cilium network policy ...")
@@ -497,6 +500,7 @@ class SysdumpCollector(object):
         self.collect_logs("io.cilium/app=operator", [])
         log.info("collecting hubble logs ...")
         self.collect_logs(self.hubble_labels, node_ip_filter)
+        self.collect_logs(self.hubble_relay_labels, node_ip_filter)
 
     def archive(self):
         filename = self.output or self.sysdump_dir_name


### PR DESCRIPTION
It runs gops and has logs which are useful to be collected.

In order for gops dump to work, cilium/cilium#11372 must have been applied.