### PR TITLE
Use asyncio for improved execution speed

### DIFF
--- a/cilium-sysdump/__main__.py
+++ b/cilium-sysdump/__main__.py
@@ -23,6 +23,7 @@ import sysdumpcollector
 import os
 import time
 import distutils.util
+import asyncio
 
 log = logging.getLogger(__name__)
 
@@ -84,6 +85,8 @@ if __name__ == "__main__":
                              'cilium bugtool output will'
                              ' not be collected.'
                              'Defaults to "false".')
+    parser.add_argument('-j', '--concurrent-jobs', default=0, type=int,
+                        help="Number of concurrent operations to perform.")
 
     args = parser.parse_args()
 
@@ -125,12 +128,13 @@ if __name__ == "__main__":
             args.output,
             args.quick,
             args.cilium_labels,
-            args.hubble_labels)
-        sysdumpcollector.collect(args.nodes)
+            args.hubble_labels,
+            args.concurrent_jobs,
+        )
+        # asyncio.set_child_watcher(asyncio.unix_events.FastChildWatcher())
+        asyncio.run(sysdumpcollector.collect(args.nodes))
         sysdumpcollector.archive()
         sys.exit(0)
     except AttributeError:
         log.exception("Fatal error in collecting sysdump")
         sys.exit(1)
-
-    sys.exit(0)

--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -97,11 +97,19 @@ class SysdumpCollector(object):
     async def collect_logs(self, label_selector, node_ip_filter):
 
         must_exist = not("hubble" in label_selector)  # hubble is optional
-        jobs = [
-            self.collect_logs_per_pod(pod) async for pod
-            in utils.get_pods_status_iterator_by_labels(
-                label_selector, node_ip_filter, must_exist=must_exist)
-        ]
+        # This could be a list comprehension, but would require Python 3.7+
+        # jobs = [
+        #     self.collect_logs_per_pod(pod) async for pod
+        #     in utils.get_pods_status_iterator_by_labels(
+        #         label_selector, node_ip_filter, must_exist=must_exist)
+        # ]
+        jobs = []
+        async for job in utils.get_pods_status_iterator_by_labels(
+                label_selector,
+                node_ip_filter,
+                must_exist=must_exist,
+        ):
+            jobs.append(job)
         await asyncio.gather(*jobs)
 
     async def collect_logs_per_pod(self, podstatus):
@@ -195,11 +203,13 @@ class SysdumpCollector(object):
 
     async def collect_gops(self, label_selector, node_ip_filter, type_of_stat):
         must_exist = not("hubble" in label_selector)  # hubble is optional
-        jobs = [
-            self.collect_gops_per_pod(pod, type_of_stat) async for pod
-            in utils.get_pods_status_iterator_by_labels(
-                label_selector, node_ip_filter, must_exist=must_exist,)
-        ]
+        jobs = []
+        async for job in utils.get_pods_status_iterator_by_labels(
+                label_selector,
+                node_ip_filter,
+                must_exist=must_exist,
+        ):
+            jobs.append(job)
         await asyncio.gather(*jobs)
 
     async def collect_gops_per_pod(self, podstatus, type_of_stat):
@@ -335,12 +345,13 @@ class SysdumpCollector(object):
 
     async def collect_cilium_bugtool_output(self, label_selector, node_ip_filter):  # noqa
         must_exist = not("hubble" in label_selector)  # hubble is optional
-        jobs = [
-            self.collect_cilium_bugtool_output_per_pod(pod) async for pod
-            in utils.get_pods_status_iterator_by_labels(label_selector,
-                                                        node_ip_filter,
-                                                        must_exist=must_exist)
-        ]
+        jobs = []
+        async for job in utils.get_pods_status_iterator_by_labels(
+                label_selector,
+                node_ip_filter,
+                must_exist=must_exist,
+        ):
+            jobs.append(job)
         await asyncio.gather(*jobs)
 
     async def collect_cilium_bugtool_output_per_pod(self, podstatus):


### PR DESCRIPTION
This change converts all `subprocess.check_output` calls in cilium-sysdump to an asynchronous version. This makes running all collection jobs concurrently relatively trivial. By default, the script will run everything at once, but a new command line parameter has been added that allows users to set a cap on the number of concurrent jobs run at any given time.

As a result of these changes, cilium-sysdump would require Python 3.6 at a minimum.

Closes #88