### PR TITLE
Collect Hubble UI logs and deployment YAMLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The following options are supported:
 - `--hubble-ns HUBBLE_NS`: specify the k8s namespace Hubble is running in
 - `--hubble-relay-labels HUBBLE_RELAY_LABELS`: labels of hubble-relay pods running in the cluster
 - `--hubble-relay-ns HUBBLE_RELAY_NS`: specify the k8s namespace Hubble-Relay is running in
+- `--hubble-ui-labels HUBBLE_UI_LABELS`: labels of Hubble UI pods running in the cluster
+- `--hubble-ui-ns HUBBLE_UI_NS`: specify the k8s namespace Hubble UI is running in
 - `--nodes NODES`: only return logs for particular nodes specified by a comma separated list of node IP addresses or node names.
 - `--output OUTPUT`: output filename without .zip extension
 - `--quick QUICK`: enable quick mode. Logs and cilium bugtool output will to "false"

--- a/cilium-sysdump/__main__.py
+++ b/cilium-sysdump/__main__.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import defaults
-
-from _version import __version__
-import utils
-import namespace
-import logging
-import sys
 import argparse
-import sysdumpcollector
-import os
-import time
 import distutils.util
+import logging
+import os
+import sys
+import time
 
+import defaults
+import namespace
+import sysdumpcollector
+import utils
+from _version import __version__
 
 log = logging.getLogger(__name__)
 

--- a/cilium-sysdump/__main__.py
+++ b/cilium-sysdump/__main__.py
@@ -137,9 +137,9 @@ if __name__ == '__main__':
             'pod', label=args.hubble_relay_labels, must_exist=False,
         )
         if status is None:
-            namespace.hubble_relay_labels = args.hubble_relay_labels
+            namespace.hubble_relay_ns = args.hubble_relay_ns
         else:
-            namespace.hubble_relay_labels = status[0]
+            namespace.hubble_relay_ns = status[0]
     except RuntimeError:
         namespace.hubble_relay_ns = args.hubble_relay_ns
         pass

--- a/cilium-sysdump/__main__.py
+++ b/cilium-sysdump/__main__.py
@@ -62,6 +62,10 @@ if __name__ == '__main__':
                         default=defaults.hubble_relay_ns,
                         help='specify the k8s namespace Hubble-Relay is' +
                              ' running in')
+    parser.add_argument('--hubble-ui-ns', type=str,
+                        default=defaults.hubble_ui_ns,
+                        help='specify the k8s namespace Hubble-UI is' +
+                             ' running in')
     parser.add_argument('--cilium-labels',
                         help='labels of cilium pods running in '
                         'the cluster',
@@ -74,6 +78,10 @@ if __name__ == '__main__':
                         help='labels of hubble-relay pods running in '
                         'the cluster',
                         default=defaults.hubble_relay_labels)
+    parser.add_argument('--hubble-ui-labels',
+                        help='labels of hubble-ui pods running in '
+                        'the cluster',
+                        default=defaults.hubble_ui_labels)
     parser.add_argument('-v', '--version', required=False, action='store_true',
                         help='get the version of this tool')
 
@@ -144,6 +152,18 @@ if __name__ == '__main__':
         namespace.hubble_relay_ns = args.hubble_relay_ns
         pass
 
+    try:
+        status = utils.get_resource_status(
+            'pod', label=args.hubble_ui_labels, must_exist=False,
+        )
+        if status is None:
+            namespace.hubble_ui_ns = args.hubble_ui_ns
+        else:
+            namespace.hubble_ui_ns = status[0]
+    except RuntimeError:
+        namespace.hubble_ui_ns = args.hubble_ui_ns
+        pass
+
     log.debug('Fetching nodes to determine cluster size...')
     nodes = utils.get_nodes()
     if not nodes:
@@ -180,7 +200,8 @@ if __name__ == '__main__':
             args.quick,
             args.cilium_labels,
             args.hubble_labels,
-            args.hubble_relay_labels)
+            args.hubble_relay_labels,
+            args.hubble_ui_labels)
         sysdumpcollector.collect(args.nodes)
         sysdumpcollector.archive()
         sys.exit(0)

--- a/cilium-sysdump/defaults.py
+++ b/cilium-sysdump/defaults.py
@@ -15,13 +15,14 @@
 
 import namespace
 
-
 cilium_ns = namespace.cilium_ns
 hubble_ns = namespace.hubble_ns
 hubble_relay_ns = namespace.hubble_relay_ns
+hubble_ui_ns = namespace.hubble_ui_ns
 cilium_labels = 'k8s-app=cilium'
 hubble_labels = 'k8s-app=hubble'
 hubble_relay_labels = 'k8s-app=hubble-relay'
+hubble_ui_labels = 'k8s-app=hubble-ui'
 since = '0'
 size_limit = 1 * 1024 * 1024 * 1024
 quick = 'false'

--- a/cilium-sysdump/namespace.py
+++ b/cilium-sysdump/namespace.py
@@ -16,3 +16,4 @@
 cilium_ns = "kube-system"
 hubble_ns = cilium_ns
 hubble_relay_ns = cilium_ns
+hubble_ui_ns = cilium_ns

--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -12,19 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import namespace
 
+import functools
 import json
 import logging
 import multiprocessing
-import re
 import os
-import functools
+import re
 import shutil
 import subprocess
-import utils
-
 from multiprocessing.pool import ThreadPool
+
+import namespace
+import utils
 
 log = logging.getLogger(__name__)
 

--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -119,8 +119,8 @@ class SysdumpCollector(object):
         containers = utils.get_container_names_per_pod(podstatus.namespace,
                                                        podstatus.name)
         for container in containers:
-            log_file_name = "{}-{}".format(podstatus.name,
-                                           utils.get_current_time())
+            log_file_name = "{}-{}-{}".format(podstatus.name, container,
+                                              utils.get_current_time())
             command = "kubectl logs {} --container={} --timestamps=true " \
                       "--since={} --limit-bytes={} -n {} > {}/{}.log"
             cmd = command.format(

--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -42,7 +42,8 @@ class SysdumpCollector(object):
     def __init__(
             self,
             sysdump_dir_name, since, size_limit, output, is_quick_mode,
-            cilium_labels, hubble_labels, hubble_relay_labels):
+            cilium_labels, hubble_labels, hubble_relay_labels,
+            hubble_ui_labels):
         self.sysdump_dir_name = sysdump_dir_name
         self.since = since
         self.size_limit = size_limit
@@ -51,6 +52,7 @@ class SysdumpCollector(object):
         self.cilium_labels = cilium_labels
         self.hubble_labels = hubble_labels
         self.hubble_relay_labels = hubble_relay_labels
+        self.hubble_ui_labels = hubble_ui_labels
 
     def collect_nodes_overview(self):
         log.info("collecting nodes overview ...")
@@ -602,6 +604,8 @@ class SysdumpCollector(object):
                           [])
         self.collect_logs(pool, "hubble", self.hubble_labels, node_filter)
         self.collect_logs(pool, "hubble relay", self.hubble_relay_labels,
+                          node_filter)
+        self.collect_logs(pool, "hubble ui", self.hubble_ui_labels,
                           node_filter)
 
         pool.close()

--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -588,6 +588,8 @@ class SysdumpCollector(object):
         pool.apply_async(self.collect_ciliumnodes, ())
         pool.apply_async(self.collect_daemonset_yaml, ("cilium", ))
         pool.apply_async(self.collect_daemonset_yaml, ("hubble", ))
+        pool.apply_async(self.collect_deployment_yaml, ("hubble-relay", ))
+        pool.apply_async(self.collect_deployment_yaml, ("hubble-ui", ))
         pool.apply_async(self.collect_deployment_yaml, ("cilium-operator", ))
         pool.apply_async(self.collect_cilium_configmap, ())
 

--- a/cilium-sysdump/utils.py
+++ b/cilium-sysdump/utils.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import net
-
 import collections
 import logging
 import subprocess
 import sys
 import time
+
+import net
 
 FORMAT = '%(levelname)s %(message)s'
 # TODO: Make the logging level configurable.


### PR DESCRIPTION
Closes https://github.com/cilium/cilium-sysdump/issues/111.

Contains a small bugfix to the Relay namespace fallback logic, but I assume this is only rarely used in practice.

@seanmwinn In case there are any other existing scripts that depend on the log filename format, they now contain the name of the container the logs belong to. Otherwise, the Hubble UI logs would clobber each other.