### PR TITLE
Collect logs for init containers

### DIFF
--- a/cilium-sysdump/sysdumpcollector.py
+++ b/cilium-sysdump/sysdumpcollector.py
@@ -218,7 +218,8 @@ class SysdumpCollector(object):
 
     def collect_gops_per_pod(self, podstatus, type_of_stat):
         containers = utils.get_container_names_per_pod(podstatus.namespace,
-                                                       podstatus.name)
+                                                       podstatus.name,
+                                                       init_containers=False)
         for container in containers:
             if container == "hubble-ui":
                 continue  # gops does not run in hubble-ui container

--- a/cilium-sysdump/utils.py
+++ b/cilium-sysdump/utils.py
@@ -254,11 +254,12 @@ def get_pods_status_iterator_by_labels(label_selector, node_filter,
                         namespace=split_line[4])
 
 
-def get_container_names_per_pod(pod_namespace, pod_name):
+def get_container_names_per_pod(pod_namespace, pod_name, init_containers=True):
     """Return the list of container names in the given pod"""
     cmd = "kubectl get pods {} -n {} " \
-          "-o jsonpath='{}'".format(
-              pod_name, pod_namespace, "{.spec.containers[*].name}"
+          "-o jsonpath='{} {}'".format(
+              pod_name, pod_namespace, "{.spec.containers[*].name}",
+              "{.spec.initContainers[*].name}" if init_containers else ""
           )
 
     output = ""


### PR DESCRIPTION
Previously we only collected regular container logs, but missed the init
container logs. Gather these as well, they can be useful for debugging.

Fixes: #120