### PR TITLE
Fix bug where failed subproccess terminates program

### DIFF
--- a/cilium-sysdump/utils.py
+++ b/cilium-sysdump/utils.py
@@ -262,7 +262,7 @@ def get_container_names_per_pod(pod_namespace, pod_name, init_containers=True):
               "{.spec.initContainers[*].name}" if init_containers else ""
           )
 
-    output = ""
+    output = b''
     try:
         output = subprocess.check_output(
             cmd, shell=True, stderr=subprocess.STDOUT,
@@ -282,7 +282,7 @@ def get_nodes():
     cmd = "kubectl get nodes " \
           "-o jsonpath='{}'".format("{.items[*].metadata.name}")
 
-    output = ""
+    output = b''
     try:
         output = subprocess.check_output(
             cmd, shell=True, stderr=subprocess.STDOUT,


### PR DESCRIPTION
Before this change, if the command to get container names per pod or get
nodes failed, cilium-sysdump would terminate with the error:

    Traceback (most recent call last):
      File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "cilium-sysdump.zip/__main__.py", line 168, in <module>
      File "cilium-sysdump.zip/utils.py", line 292, in get_nodes
    AttributeError: 'str' object has no attribute 'decode'
    Error: Process completed with exit code 1.

This is because the default output was initialized to an empty string,
which does not have a decode method. Instead, initialize the default
output to an empty bytes.

Signed-off-by: Tom Payne <tom@isovalent.com>